### PR TITLE
cidr check install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -58,6 +58,7 @@ MIGRATION_EXIST="false"
 # Network options
 POD_NETWORK_CIDR="10.244.0.0/16"
 SERVICE_CIDR="10.172.0.0/16"
+SKIP_CIDR="false"
 
 echo "------ Staring Gravity installer $(date '+%Y-%m-%d %H:%M:%S')  ------" >${LOG_FILE} 2>&1
 
@@ -102,6 +103,7 @@ function showhelp {
    echo "  [--k8s-base-repo-version] Kubernetes/Gravity repo version (default: ${K8S_BASE_VERSION})"
    echo "  [--k8s-infra-version] Infrastructure layer version (default: ${K8S_INFRA_VERSION})"
    echo "  [--k8s-infra-repo-version] Infrastructure repo version (default: ${K8S_INFRA_VERSION})"
+   echo "  [--skip-cidr-check] Force install without checking CIDR overlap"
    # commented below - feature disabled until we can send those params to the preflight.sh script as well
    # echo "  [--pod-network-cidr] Config pod network CIDR [Default: ${POD_NETWORK_CIDR}]"
    # echo "  [--service-cidr] Config service CIDR [Default: ${SERVICE_CIDR}]"
@@ -291,6 +293,11 @@ while test $# -gt 0; do
         shift
         continue
         ;;
+        --skip-cidr-check)
+            SKIP_CIDR="true"
+        shift
+        continue
+        ;;
         # commented below - feature disabled until we can send those params to the preflight.sh script as well
         #--pod-network-cidr)
         #shift
@@ -378,6 +385,10 @@ function cidr_check() {
 
   if [[ "$DOWNLOAD_ONLY" == "true" ]]; then
     echo "Run with --download-only -> CIDR overlap check skipped!"
+    return 0
+  fi
+  if [[ "$SKIP_CIDR" == "true" ]]; then
+    echo "Run with --skip-cidr-check -> CIDR overlap check skipped!"
     return 0
   fi
   # evaluates the list of subnets using the "ip route" command and comparing each subnet to CIDR in use

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@ set -e
 set -o pipefail
 
 # script version
-SCRIPT_VERSION="1.24.0-31"
+SCRIPT_VERSION="1.24.0-32"
 
 # Absolute path to this script
 SCRIPT=$(readlink -f "$0")
@@ -55,6 +55,10 @@ FORCE_DOWNLOAD="false"
 SKIP_CLUSTER_CHECK="false"
 MIGRATION_EXIST="false"
 
+# Network options
+POD_NETWORK_CIDR="10.244.0.0/16"
+SERVICE_CIDR="10.172.0.0/16"
+
 echo "------ Staring Gravity installer $(date '+%Y-%m-%d %H:%M:%S')  ------" >${LOG_FILE} 2>&1
 
 ## Permissions check
@@ -98,6 +102,9 @@ function showhelp {
    echo "  [--k8s-base-repo-version] Kubernetes/Gravity repo version (default: ${K8S_BASE_VERSION})"
    echo "  [--k8s-infra-version] Infrastructure layer version (default: ${K8S_INFRA_VERSION})"
    echo "  [--k8s-infra-repo-version] Infrastructure repo version (default: ${K8S_INFRA_VERSION})"
+   # commented below - feature disabled until we can send those params to the preflight.sh script as well
+   # echo "  [--pod-network-cidr] Config pod network CIDR [Default: ${POD_NETWORK_CIDR}]"
+   # echo "  [--service-cidr] Config service CIDR [Default: ${SERVICE_CIDR}]"
    echo "  [--driver-method] Nvidia driver installation method [host|container] (default: ${NVIDIA_DRIVER_METHOD})"
    echo "  [--driver-version] Nvidia driver version (requires --driver-method=container) [410-104|418-113] (default: ${NVIDIA_DRIVER_VERSION})"
    echo "  [--driver-package-version] Nvidia driver package version (default: ${NVIDIA_DRIVER_PACKAGE_VERSION})"
@@ -284,6 +291,19 @@ while test $# -gt 0; do
         shift
         continue
         ;;
+        # commented below - feature disabled until we can send those params to the preflight.sh script as well
+        #--pod-network-cidr)
+        #shift
+        #    POD_NETWORK_CIDR=${1:-$POD_NETWORK_CIDR}
+        #shift
+        #continue
+        #;;
+        #--service-cidr)
+        #shift
+        #    SERVICE_CIDR=${1:-$SERVICE_CIDR}
+        #shift
+        #continue
+        #;;
     esac
     break
 done
@@ -304,6 +324,89 @@ RHEL_NVIDIA_DRIVER_CONTAINER_URL="${S3_BUCKET_URL}/nvidia-driver/${NVIDIA_DRIVER
 RHEL_NVIDIA_DRIVER_CONTAINER_MD5_URL="${S3_BUCKET_URL}/nvidia-driver/${NVIDIA_DRIVER_REPO_VERSION}/nvidia-driver-${NVIDIA_DRIVER_VERSION}-rhel7-${NVIDIA_DRIVER_PACKAGE_VERSION}.md5"
 UBUNTU_NVIDIA_DRIVER_CONTAINER_FILE="${UBUNTU_NVIDIA_DRIVER_CONTAINER_URL##*/}"
 RHEL_NVIDIA_DRIVER_CONTAINER_FILE="${RHEL_NVIDIA_DRIVER_CONTAINER_URL##*/}"
+
+function cidr_overlap() (
+  #check local cidr - This function was copied from the internet!
+  subnet1="$1"
+  subnet2="$2"
+  
+  # calculate min and max of subnet1
+  # calculate min and max of subnet2
+  # find the common range (check_overlap)
+  # print it if there is one
+
+  read_range () {
+    IFS=/ read ip mask <<<"$1"
+    IFS=. read -a octets <<< "$ip";
+    set -- "${octets[@]}";
+    min_ip=$(($1*256*256*256 + $2*256*256 + $3*256 + $4));
+    host=$((32-mask))
+    max_ip=$(($min_ip+(2**host)-1))
+    printf "%d-%d\n" "$min_ip" "$max_ip"
+  }
+
+  check_overlap () {
+    IFS=- read min1 max1 <<<"$1";
+    IFS=- read min2 max2 <<<"$2";
+    if [ "$max1" -lt "$min2" ] || [ "$max2" -lt "$min1" ]; then return; fi
+    [ "$max1" -ge "$max2" ] && max="$max2" ||   max="$max1"
+    [ "$min1" -le "$min2" ] && min="$min2" || min="$min1"
+    printf "%s-%s\n" "$(to_octets $min)" "$(to_octets $max)"
+  }
+
+  to_octets () {
+    first=$(($1>>24))
+    second=$((($1&(256*256*255))>>16))
+    third=$((($1&(256*255))>>8))
+    fourth=$(($1&255))
+    printf "%d.%d.%d.%d\n" "$first" "$second" "$third" "$fourth" 
+  }
+
+  range1="$(read_range $subnet1)"
+  range2="$(read_range $subnet2)"
+  overlap="$(check_overlap $range1 $range2)"
+  [ -n "$overlap" ] && echo "Overlap $overlap of $subnet1 and $subnet2"
+
+  # if cidr equal to install parameters exit 1 + echo notice to user
+)
+
+function cidr_check() {
+  # This function:
+  # checks if "DOWNLOAD_ONLY=true" is so returns normally
+  # checks if there is CIDR overlap with local network
+  # if there is an overlap it prints the details and terminates install script befor making changes
+
+  if [[ "$DOWNLOAD_ONLY" == "true" ]]; then
+    echo "Run with --download-only -> CIDR overlap check skipped!"
+    return 0
+  fi
+  # evaluates the list of subnets using the "ip route" command and comparing each subnet to CIDR in use
+  CIDR_LIST=$(ip route | cut -d' ' -f1)
+  for network in $CIDR_LIST; do
+    if [[ $network != "default" ]]; then
+        # solve issue when mask is /32 and does not show in the ip route correctly
+        IFS=/ read ip mask <<<"$network"
+        if [[ ${mask} ]];then echo "OK"
+          else
+            network="$network/24"
+            echo $network
+        fi
+        # calling function cidr_overlap to evaluate
+        if [[ $( cidr_overlap ${POD_NETWORK_CIDR} ${network} ) ]]; then
+          echo "Pods network CIDR Exist in network environment!!! Install terminated - nothing was done."
+          cidr_overlap ${POD_NETWORK_CIDR} ${network}
+          #echo "To run with custom CIDR use --pod-network-cidr"
+          exit 1
+        fi
+        if [[ $( cidr_overlap ${SERVICE_CIDR} ${network} ) ]]; then
+          echo "Service CIDR Exist in network environment!!! Install terminated - nothing was done."
+          cidr_overlap ${SERVICE_CIDR} ${network}
+          #echo "To run with custom CIDR use --service-cidr"
+          exit 1
+        fi
+    fi
+  done
+}
 
 function is_kubectl_exists() {
   if [ "${SKIP_CLUSTER_CHECK}" == "false" ]; then
@@ -795,6 +898,8 @@ function developer_env_install() {
 }
 
 echo "Installing ${NODE_ROLE} node with method ${INSTALL_METHOD}" | tee -a ${LOG_FILE}
+echo "Checking server environment before installing"
+cidr_check
 
 if [[ "${INSTALL_METHOD}" == "online" ]]; then
   online_packages_installation


### PR DESCRIPTION
Changes made: 
- disabled the option to select a different CIDR for install until we can send parameters to the reflight.sh
- function is now self-checking for “--download-only” switch and returns without checking is value is TRUE
- in cases of x.x.x.x/32 netmask the function is fixing the CIDR string and is handled as x.x.x.x/24
- the function will output the overlapping networks to screen